### PR TITLE
fix: enable SSL for PostgreSQL connection on Render

### DIFF
--- a/src/database/data-source.ts
+++ b/src/database/data-source.ts
@@ -9,7 +9,7 @@ import { PasswordResetCode } from '../modules/auth/auth.entity';
 export const AppDataSource = new DataSource({
   type: 'postgres',
   url: process.env.DATABASE_URL,
-  ssl: process.env.NODE_ENV === 'production' ? { rejectUnauthorized: false } : false,
+  ssl: { rejectUnauthorized: false },
   synchronize: process.env.NODE_ENV !== 'production',
   logging: process.env.NODE_ENV === 'development',
   entities: [User, Book, Comment, Favorite, PasswordResetCode],


### PR DESCRIPTION
La conexión a la base de datos en Render fallaba con ECONNRESET porque SSL 
estaba desactivado en entornos distintos a producción. Render requiere SSL 
en todas las conexiones independientemente del entorno.

Cambio: se reemplazó la condición por { rejectUnauthorized: false } fijo 
para garantizar la conexión exitosa en desarrollo y producción.
